### PR TITLE
Fix incorrect variable names for peer config generation.

### DIFF
--- a/src/profilemanager.py
+++ b/src/profilemanager.py
@@ -370,7 +370,7 @@ class ProfileManager(object):
 
                     # write endpoint information separately
                     # since it has a different format
-                    config.write(f'Endpoint = {p.__dict__["public_address"]}:{p.__dict__["listen_port"]}\n')
+                    config.write(f'Endpoint = {p.__dict__["Endpoint"]}:{p.__dict__["ListenPort"]}\n')
 
                     # if value is not empty string or None
                     for k in [p for p in p.__dict__ if p in PEER_ATTRIBUTES]:


### PR DESCRIPTION
1.3.0 fails to generate config due to mismatched variable names.

```
Traceback (most recent call last):
  File "src/wireguard_mesh_configurator.py", line 49, in <module>
    WMCShell().cmdloop()
  File "/usr/lib/python3.7/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python3.7/cmd.py", line 217, in onecmd
    return func(arg)
  File "/home/alistair/wireguard-mesh-configurator/src/wmcshell.py", line 74, in do_generateconfigs
    self.pm.generate_configs(arg)
  File "/home/alistair/wireguard-mesh-configurator/src/profilemanager.py", line 373, in generate_configs
    config.write(f'Endpoint = {p.__dict__["public_address"]}:{p.__dict__["listen_port"]}\n')
KeyError: 'public_address'
```